### PR TITLE
Add arm64 support for PY3.6

### DIFF
--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,5 +5,5 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-protobuf==3.12.0
+protobuf==3.15.6
 google-api-core==1.22.2


### PR DESCRIPTION
Hi Team,

**Package Owner**: Bhumika Paharia

**PR change Details:**
**$ Patch Details:** Following files has been modified:
**Testing/constraints-3.6.txt**: Upgraded Protobuf version from protobuf==3.12.0 to protobuf==3.15.6 
	
**$ Testing Detail :**
**Commit link:** [here](https://github.com/odidev/proto-plus-python/pull/1/commits/0c4b70d339c6c2e1b13427db6066e6211e0f29a8)

**$ PR Description**: Here is my commit message :
Add arm64 support for PY3.6
As Source file is not present in version 3.12.0 the latter version have source tar file through which arm64 wheel is getting created. 

Here is my PR description -
The following files have been modified:
In **testing/constraints-3.6.txt**:
	1. Upgraded Protobuf version from protobuf==3.12.0 to protobuf==3.15.6 
As Source file is not present in version 3.12.0 the latter version have source tar file through which arm64 wheel is getting created.
 
**$Peer Reviewer:** Sakshi Sharma
**$Reviewer**: Shobhit Parashari

Thanks
Bhumika Paharia
